### PR TITLE
Feat : 편지 도메인 구현

### DIFF
--- a/src/main/java/com/ee06/wooms/domain/letters/controller/LetterController.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/controller/LetterController.java
@@ -1,15 +1,20 @@
 package com.ee06.wooms.domain.letters.controller;
 
+import com.ee06.wooms.domain.letters.dto.LetterDto;
 import com.ee06.wooms.domain.letters.dto.NewLetterRequest;
 import com.ee06.wooms.domain.letters.service.LetterService;
 import com.ee06.wooms.domain.users.dto.CustomUserDetails;
-import com.ee06.wooms.domain.users.dto.auth.ModifyPasswordInfo;
 import com.ee06.wooms.global.common.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +34,20 @@ public class LetterController {
         return ResponseEntity.ok(letterService.createNewLetter(currentUser, newLetterRequest));
     }
 
+    @GetMapping("/letters")
+    public ResponseEntity<Page<LetterDto>> getLetters(@AuthenticationPrincipal CustomUserDetails currentUser,
+                                                      @PageableDefault(size = 5) Pageable pageable) {
+        return ResponseEntity.ok(letterService.getSortedLettersBeforeToday(currentUser, pageable));
+    }
 
+    @GetMapping("/letters/amount")
+    public ResponseEntity<Integer> getFutureLettersAmount(@AuthenticationPrincipal CustomUserDetails currentUser) {
+        int amount = letterService.countFutureLetters(currentUser);
+        return ResponseEntity.ok(amount);
+    }
 
-
+    @DeleteMapping("/letters/{letterId}")
+    public ResponseEntity<CommonResponse> deleteLetter(@PathVariable("letterId") Long letterId, @AuthenticationPrincipal CustomUserDetails currentUser) {
+        return ResponseEntity.ok(letterService.deleteLetter(currentUser, letterId));
+    }
 }

--- a/src/main/java/com/ee06/wooms/domain/letters/dto/LetterDto.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/dto/LetterDto.java
@@ -1,0 +1,24 @@
+package com.ee06.wooms.domain.letters.dto;
+
+import com.ee06.wooms.domain.letters.entity.LetterStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LetterDto {
+    private Long id;
+    private String content;
+    private LocalDateTime receiveDate;
+    private String senderName;
+    private String receiverName;
+    private LetterStatus status;
+}

--- a/src/main/java/com/ee06/wooms/domain/letters/entity/Letter.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/entity/Letter.java
@@ -1,6 +1,7 @@
 package com.ee06.wooms.domain.letters.entity;
 
 
+import com.ee06.wooms.domain.letters.dto.LetterDto;
 import com.ee06.wooms.domain.users.entity.User;
 import com.ee06.wooms.global.audit.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -50,4 +51,6 @@ public class Letter extends BaseTimeEntity {
 
     @Column(name = "receive_date")
     private LocalDateTime receiveDate;
+
+
 }

--- a/src/main/java/com/ee06/wooms/domain/letters/exception/LetterExceptionHandler.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/exception/LetterExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ee06.wooms.domain.letters.exception;
 
 import com.ee06.wooms.domain.letters.exception.ex.NotInSameWoomsException;
+import com.ee06.wooms.domain.letters.exception.ex.NotValidLetterException;
 import com.ee06.wooms.domain.wooms.exception.ex.WoomsAlreadyMemberException;
 import com.ee06.wooms.domain.wooms.exception.ex.WoomsAlreadyWaitingException;
 import com.ee06.wooms.domain.wooms.exception.ex.WoomsNotValidEnrollmentException;
@@ -21,5 +22,11 @@ public class LetterExceptionHandler {
     public ResponseEntity<Object> woomsAlreadyMemberException(NotInSameWoomsException e) {
         return ErrorCodeUtils.build(ErrorCode.NOT_IN_SAME_GROUP);
     }
+
+    @ExceptionHandler(NotValidLetterException.class)
+    public ResponseEntity<Object> notValidLetter(NotValidLetterException e) {
+        return ErrorCodeUtils.build(ErrorCode.NOT_VALID_LETTER);
+    }
+
 
 }

--- a/src/main/java/com/ee06/wooms/domain/letters/exception/ex/NotValidLetterException.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/exception/ex/NotValidLetterException.java
@@ -1,0 +1,15 @@
+package com.ee06.wooms.domain.letters.exception.ex;
+
+import com.ee06.wooms.global.exception.ErrorCode;
+import lombok.Getter;
+
+import static com.ee06.wooms.global.exception.ErrorCode.NOT_VALID_LETTER;
+
+@Getter
+public class NotValidLetterException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public NotValidLetterException() {
+        this.errorCode = NOT_VALID_LETTER;
+    }
+}

--- a/src/main/java/com/ee06/wooms/domain/letters/repository/LetterRepository.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/repository/LetterRepository.java
@@ -1,10 +1,29 @@
 package com.ee06.wooms.domain.letters.repository;
 
 import com.ee06.wooms.domain.letters.entity.Letter;
+import com.ee06.wooms.domain.letters.entity.LetterStatus;
 import com.ee06.wooms.domain.users.entity.Mail;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface LetterRepository extends CrudRepository<Letter, Long> {
+public interface LetterRepository extends JpaRepository<Letter, Long> {
+
+    @Query("SELECT l " +
+            " FROM Letter l " +
+            "WHERE l.receiver.uuid = :userUuid AND l.receiveDate < :cutoffDate " +
+            "ORDER BY CASE WHEN l.status = 0 THEN 1 ELSE 2 END, l.receiveDate DESC")
+    Page<Letter> findByReceiverUuidAndReceiveDateBefore(@Param("userUuid") UUID userUuid,
+                                                        @Param("cutoffDate") LocalDateTime cutoffDate,
+                                                        Pageable pageable);
+
+    int countByReceiverUuidAndReceiveDateAfter(UUID receiverUuid, LocalDateTime dateTime);
 }

--- a/src/main/java/com/ee06/wooms/domain/letters/service/LetterService.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/service/LetterService.java
@@ -93,7 +93,7 @@ public class LetterService {
         Letter letter = letterRepository.findById(letterId)
                 .orElseThrow(NotValidLetterException::new);
 
-        if (!letter.getReceiver().getUuid().equals(UUID.fromString(customUserDetails.getUuid()))) {
+        if (!Objects.equals(letter.getReceiver().getUuid(), UUID.fromString(customUserDetails.getUuid()))) {
             throw new UserNotAllowedException();
         }
 

--- a/src/main/java/com/ee06/wooms/domain/letters/service/LetterService.java
+++ b/src/main/java/com/ee06/wooms/domain/letters/service/LetterService.java
@@ -1,27 +1,33 @@
 package com.ee06.wooms.domain.letters.service;
 
 import com.ee06.wooms.domain.enrollments.repository.EnrollmentRepository;
+import com.ee06.wooms.domain.letters.dto.LetterDto;
 import com.ee06.wooms.domain.letters.dto.NewLetterRequest;
 import com.ee06.wooms.domain.letters.entity.Letter;
 import com.ee06.wooms.domain.letters.entity.LetterStatus;
 import com.ee06.wooms.domain.letters.exception.ex.NotInSameWoomsException;
+import com.ee06.wooms.domain.letters.exception.ex.NotValidLetterException;
 import com.ee06.wooms.domain.letters.repository.LetterRepository;
 import com.ee06.wooms.domain.users.dto.CustomUserDetails;
 import com.ee06.wooms.domain.users.entity.User;
+import com.ee06.wooms.domain.users.exception.ex.UserNotAllowedException;
 import com.ee06.wooms.domain.users.exception.ex.UserNotFoundException;
 import com.ee06.wooms.domain.users.repository.UserRepository;
 import com.ee06.wooms.global.common.CommonResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
 @Transactional
 @Service
+@Slf4j
 public class LetterService {
 
     private final LetterRepository letterRepository;
@@ -36,19 +42,30 @@ public class LetterService {
             throw new NotInSameWoomsException();
         }
 
+        LocalDateTime adjustedReceiveDateTime = newLetterRequest.getReceiveDateTime()
+                .withHour(12);
+
         Letter letter = Letter.builder()
                 .sender(currentUser)
                 .receiver(targetUser)
                 .content(newLetterRequest.getContent())
                 .sentDate(LocalDateTime.now())
-                .receiveDate(newLetterRequest.getReceiveDateTime())
+                .receiveDate(adjustedReceiveDateTime)
                 .status(LetterStatus.UNREAD)
                 .build();
+
         letterRepository.save(letter);
 
         return new CommonResponse("ok");
     }
 
+    public Page<LetterDto> getSortedLettersBeforeToday(CustomUserDetails customUserDetails, Pageable pageable) {
+        UUID userUuid = UUID.fromString(customUserDetails.getUuid());
+
+        Page<Letter> letters = letterRepository.findByReceiverUuidAndReceiveDateBefore(userUuid, LocalDateTime.now(), pageable);
+
+        return letters.map(this::toLetterDto);
+    }
 
     private User fetchUser(String userUuidStr) {
         UUID userUuid = UUID.fromString(userUuidStr);
@@ -56,4 +73,31 @@ public class LetterService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    private LetterDto toLetterDto(Letter letter) {
+        return LetterDto.builder()
+                .id(letter.getId())
+                .senderName(letter.getSender().getName())
+                .receiverName(letter.getReceiver().getName())
+                .content(letter.getContent())
+                .receiveDate(letter.getReceiveDate())
+                .status(letter.getStatus())
+                .build();
+    }
+
+    public int countFutureLetters(CustomUserDetails customUserDetails) {
+        UUID userUuid = UUID.fromString(customUserDetails.getUuid());
+        return letterRepository.countByReceiverUuidAndReceiveDateAfter(userUuid, LocalDateTime.now());
+    }
+
+    public CommonResponse deleteLetter(CustomUserDetails customUserDetails, Long letterId) {
+        Letter letter = letterRepository.findById(letterId)
+                .orElseThrow(NotValidLetterException::new);
+
+        if (!letter.getReceiver().getUuid().equals(UUID.fromString(customUserDetails.getUuid()))) {
+            throw new UserNotAllowedException();
+        }
+
+        letterRepository.delete(letter);
+        return new CommonResponse("ok");
+    }
 }

--- a/src/main/java/com/ee06/wooms/domain/users/exception/UserExceptionHandler.java
+++ b/src/main/java/com/ee06/wooms/domain/users/exception/UserExceptionHandler.java
@@ -50,4 +50,9 @@ public class UserExceptionHandler {
         return ErrorCodeUtils.build(ErrorCode.TOO_LONG_NICKNAME_USER);
     }
 
+    @ExceptionHandler(UserNotAllowedException.class)
+    public ResponseEntity<Object> notMatchedPassword(UserNotAllowedException e) {
+        return ErrorCodeUtils.build(ErrorCode.UN_AUTHENTICATED_USER);
+    }
+
 }

--- a/src/main/java/com/ee06/wooms/domain/users/exception/ex/UserNotAllowedException.java
+++ b/src/main/java/com/ee06/wooms/domain/users/exception/ex/UserNotAllowedException.java
@@ -1,0 +1,16 @@
+package com.ee06.wooms.domain.users.exception.ex;
+
+import com.ee06.wooms.global.exception.ErrorCode;
+import lombok.Getter;
+
+import static com.ee06.wooms.global.exception.ErrorCode.NOT_MATCHED_PASSWORD_USER;
+import static com.ee06.wooms.global.exception.ErrorCode.UN_AUTHENTICATED_USER;
+
+@Getter
+public class UserNotAllowedException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public UserNotAllowedException() {
+        this.errorCode = UN_AUTHENTICATED_USER;
+    }
+}

--- a/src/main/java/com/ee06/wooms/global/exception/ErrorCode.java
+++ b/src/main/java/com/ee06/wooms/global/exception/ErrorCode.java
@@ -49,7 +49,8 @@ public enum ErrorCode {
     EXIST_WROTE_COMMENT(HttpStatus.BAD_REQUEST, "오늘 이미 방명록을 작성하였습니다."),
 
     //======================= Letter 예외 ======================//
-    NOT_IN_SAME_GROUP(HttpStatus.BAD_REQUEST, "해당 유저와 같은 그룹에 속해 있지 않습니다.");
+    NOT_IN_SAME_GROUP(HttpStatus.BAD_REQUEST, "해당 유저와 같은 그룹에 속해 있지 않습니다."),
+    NOT_VALID_LETTER(HttpStatus.NOT_FOUND, "유효하지 않은 레터입니다.");
 
     private final HttpStatus httpStatus;
     private String message;


### PR DESCRIPTION
## 🙆‍♂️ Issue
#61 

## 📝 Description
편지 도메인을 구현했습니다.
이제 도착한 편지의 목록을 5개 단위로 페이징하여 조회가 가능합니다.
편지를 삭제할 수 있습니다.
미래에 도착할 편지의 수를 알 수 있습니다.

## ✨ Feature
어떤 기능인지 나열해주세요.
1. 도착한 편지 페이징 단위 조회
2. 편지 삭제
3. 미래 편지의 수 확인

## 👌 Review
This closes #61 
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
