### PR TITLE
Refactor : ChatGpt Prompt 수정, 방명록 글자 수 수정

### DIFF
--- a/src/main/java/com/ee06/wooms/domain/comments/dto/CommentRequest.java
+++ b/src/main/java/com/ee06/wooms/domain/comments/dto/CommentRequest.java
@@ -16,6 +16,6 @@ import org.hibernate.validator.constraints.Length;
 public class CommentRequest {
 
     @NotNull
-    @Length(min = 1, max = 20)
+    @Length(min = 1, max = 30)
     private String content;
 }

--- a/src/main/java/com/ee06/wooms/global/ai/service/AIService.java
+++ b/src/main/java/com/ee06/wooms/global/ai/service/AIService.java
@@ -21,7 +21,7 @@ public class AIService {
     private final OpenAiAudioSpeechOptions speechOptions;
 
     public String convertScript(String content, String nickname) {
-        ChatResponse chatResponse = chatClient.prompt().user("사용자 이름: " + nickname + content).call().chatResponse();
+        ChatResponse chatResponse = chatClient.prompt().user( content + "\"사용자 이름: \"" + nickname).call().chatResponse();
         AssistantMessage chatOutput = chatResponse.getResult().getOutput();
 
         return chatOutput.getContent();

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,5 +1,5 @@
 spring.jpa.open-in-view=false
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.properties.hibernate.format_sql=true;
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=false;
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.profiles.include=auth
 
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show_sql=false
+spring.jpa.properties.hibernate.format_sql=false


### PR DESCRIPTION
## 🙆‍♂️ Issue
#149 

## 📝 Description
ChatGpt Prompt 수정, 방명록 글자 수 수정, SQL 로깅 삭제

## ✨ Feature
어떤 기능인지 나열해주세요.
1. ChatGpt Prompt 수정, 순서 변경
2. 방명록 글자 수 수정, 20 -> 30
3. SQL 로깅 삭제

## 👌 Review
This closes #149 
