### PR TITLE
Fix : 소켓 연결 및 유실 관련 정책 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,17 +4,17 @@ name: Backend CI/CD to EC2
 
 on:
   push:
-    branches: [ 'fix#160' ]
+    branches: [ 'develop#2' ]
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout fix#160
+      - name: Checkout develop#2
         uses: actions/checkout@v3
         with:
-          ref: 'fix#160'
+          ref: 'develop#2'
 
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,17 +4,17 @@ name: Backend CI/CD to EC2
 
 on:
   push:
-    branches: [ 'develop#2' ]
+    branches: [ 'fix#160' ]
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout develop#2
+      - name: Checkout fix#160
         uses: actions/checkout@v3
         with:
-          ref: 'develop#2'
+          ref: 'fix#160'
 
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew

--- a/src/main/java/com/ee06/wooms/domain/chat/ChannelRepository.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/ChannelRepository.java
@@ -9,14 +9,15 @@ import java.util.concurrent.ConcurrentMap;
 
 @Component
 public class ChannelRepository {
-    private ConcurrentMap<UUID, Channel> channelCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<UUID, Channel> channelCache = new ConcurrentHashMap<>();
 
     public void put(UUID key, Channel value) {
         channelCache.put(key, value);
     }
 
     public Channel get(UUID key) {
-        return channelCache.getOrDefault(key, new Channel());
+        return channelCache.computeIfAbsent(key, k -> new Channel());
+//        return channelCache.getOrDefault(key, new Channel());
     }
     public void remove(UUID key) { this.channelCache.remove(key); }
 

--- a/src/main/java/com/ee06/wooms/domain/chat/SessionRepository.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/SessionRepository.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentMap;
 
 @Component
 public class SessionRepository {
-    private ConcurrentMap<String, Woom> sessionCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Woom> sessionCache = new ConcurrentHashMap<>();
 
     public void put(String key, Woom value) {
         sessionCache.put(key, value);

--- a/src/main/java/com/ee06/wooms/domain/chat/SessionRepository.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/SessionRepository.java
@@ -14,9 +14,7 @@ public class SessionRepository {
         sessionCache.put(key, value);
     }
 
-    public Woom get(String key) {
-        return sessionCache.getOrDefault(key, Woom.DefaultWoom());
-    }
+    public Woom get(String key) { return sessionCache.get(key); }
 
     public void remove(String key) { this.sessionCache.remove(key); }
 

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
@@ -2,6 +2,7 @@ package com.ee06.wooms.domain.chat.common;
 
 import com.ee06.wooms.domain.chat.ChannelRepository;
 import com.ee06.wooms.domain.chat.SessionRepository;
+import com.ee06.wooms.domain.chat.dto.MoveMessage;
 import com.ee06.wooms.domain.chat.entity.Channel;
 import com.ee06.wooms.domain.chat.entity.Woom;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -25,17 +28,26 @@ public class ChannelDisconnectListener {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = headerAccessor.getSessionId();
         log.info("Handling disconnect for STOMP session: {}", sessionId);
-
+        var principal = headerAccessor.getUser();
         try {
-            Woom woom = sessionRepository.get(sessionId); // ← 아래에서 null 반환하도록 변경 추천
+            Woom woom = sessionRepository.get(sessionId);
             if (woom != null && woom.getWoomsId() != null) {
                 Channel channel = channelRepository.get(woom.getWoomsId());
                 if (channel != null) {
-                    channel.removeWoom(woom); // Map 기준 제거
-                    // put 불필요
+                    channel.removeWoom(woom);
+                    log.info("Removed woom: {}", woom.getWoomsId());
                     messagingTemplate.convertAndSend("/ws/wooms/disconnect/" + woom.getWoomsId(), woom);
                 }
+                channel.getWooms().forEach(tempWoom -> {
+                    messagingTemplate.convertAndSendToUser(
+                            principal.getName(),
+                            "/queue/init",
+                            MoveMessage.of(tempWoom)
+                    );
+                    log.info("개인 큐 발송 !");
+                });
             }
+
             sessionRepository.remove(sessionId);
         } catch (Exception e) {
             log.error("Error handling disconnect: ", e);

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
@@ -31,8 +31,8 @@ public class ChannelDisconnectListener {
         var principal = headerAccessor.getUser();
         try {
             Woom woom = sessionRepository.get(sessionId);
-            log.info("{sessionId: {}", sessionId);
-            log.info("{woomsId: {}", woom.getWoomsId());
+            log.info("sessionId: {}", sessionId);
+            log.info("woomsId: {}", woom.getWoomsId());
             if (woom != null && woom.getWoomsId() != null) {
                 Channel channel = channelRepository.get(woom.getWoomsId());
                 log.info("channel: {}", channel);

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
@@ -27,21 +27,15 @@ public class ChannelDisconnectListener {
         log.info("Handling disconnect for STOMP session: {}", sessionId);
 
         try {
-            Woom woom = sessionRepository.get(sessionId);
+            Woom woom = sessionRepository.get(sessionId); // ← 아래에서 null 반환하도록 변경 추천
             if (woom != null && woom.getWoomsId() != null) {
                 Channel channel = channelRepository.get(woom.getWoomsId());
                 if (channel != null) {
-                    channel.removeWoom(woom);
-                    channelRepository.put(woom.getWoomsId(), channel);
-
-                    messagingTemplate.convertAndSend(
-                            "/ws/wooms/disconnect/" + woom.getWoomsId(),
-                            woom
-                    );
-
+                    channel.removeWoom(woom); // Map 기준 제거
+                    // put 불필요
+                    messagingTemplate.convertAndSend("/ws/wooms/disconnect/" + woom.getWoomsId(), woom);
                 }
             }
-
             sessionRepository.remove(sessionId);
         } catch (Exception e) {
             log.error("Error handling disconnect: ", e);

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
@@ -31,14 +31,13 @@ public class ChannelDisconnectListener {
         var principal = headerAccessor.getUser();
         try {
             Woom woom = sessionRepository.get(sessionId);
-            log.info("sessionId: {}", sessionId);
-            log.info("woomsId: {}", woom.getWoomsId());
+//            log.info("sessionId: {}", sessionId);
+//            log.info("woomsId: {}", woom.getWoomsId());
             if (woom != null && woom.getWoomsId() != null) {
                 Channel channel = channelRepository.get(woom.getWoomsId());
-                log.info("channel: {}", channel);
+//                log.info("channel: {}", channel);
                 if (channel != null) {
                     channel.removeWoom(woom);
-                    log.info("Removed woom: {}", woom.getWoomsId());
                     messagingTemplate.convertAndSend("/ws/wooms/disconnect/" + woom.getWoomsId(), woom);
                 }
                 channel.getWooms().forEach(tempWoom -> {
@@ -47,7 +46,6 @@ public class ChannelDisconnectListener {
                             "/queue/init",
                             MoveMessage.of(tempWoom)
                     );
-                    log.info("개인 큐 발송 !");
                 });
             }
 

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
@@ -31,8 +31,11 @@ public class ChannelDisconnectListener {
         var principal = headerAccessor.getUser();
         try {
             Woom woom = sessionRepository.get(sessionId);
+            log.info("{sessionId: {}", sessionId);
+            log.info("{woomsId: {}", woom.getWoomsId());
             if (woom != null && woom.getWoomsId() != null) {
                 Channel channel = channelRepository.get(woom.getWoomsId());
+                log.info("channel: {}", channel);
                 if (channel != null) {
                     channel.removeWoom(woom);
                     log.info("Removed woom: {}", woom.getWoomsId());

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelDisconnectListener.java
@@ -27,30 +27,22 @@ public class ChannelDisconnectListener {
         log.info("Handling disconnect for STOMP session: {}", sessionId);
 
         try {
-            // Get user information from session repository
             Woom woom = sessionRepository.get(sessionId);
             if (woom != null && woom.getWoomsId() != null) {
-                // Remove from channel
                 Channel channel = channelRepository.get(woom.getWoomsId());
                 if (channel != null) {
                     channel.removeWoom(woom);
                     channelRepository.put(woom.getWoomsId(), channel);
 
-                    // Notify others about disconnection
                     messagingTemplate.convertAndSend(
                             "/ws/wooms/disconnect/" + woom.getWoomsId(),
                             woom
                     );
 
-                    log.info("Removed user {} from channel {}",
-                            woom.getNickname(), woom.getWoomsId());
                 }
             }
 
-            // Clean up session
             sessionRepository.remove(sessionId);
-            log.info("Cleaned up session: {}", sessionId);
-
         } catch (Exception e) {
             log.error("Error handling disconnect: ", e);
         }

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelSubscribeListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelSubscribeListener.java
@@ -34,14 +34,12 @@ public class ChannelSubscribeListener {
         String idStr = destination.substring(prefix.length());
         UUID woomsId = UUID.fromString(idStr);
         Channel channel = channelRepository.get(woomsId);
-
         channel.getWooms().forEach(woom -> {
             template.convertAndSendToUser(
                     principal.getName(),
                     "/queue/init",
                     MoveMessage.of(woom)
             );
-            log.info("개인 큐 발송 !");
         });
     }
 }

--- a/src/main/java/com/ee06/wooms/domain/chat/common/ChannelSubscribeListener.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/ChannelSubscribeListener.java
@@ -1,0 +1,47 @@
+package com.ee06.wooms.domain.chat.common;
+
+import com.ee06.wooms.domain.chat.ChannelRepository;
+import com.ee06.wooms.domain.chat.dto.MoveMessage;
+import com.ee06.wooms.domain.chat.entity.Channel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChannelSubscribeListener {
+
+    private final ChannelRepository channelRepository;
+    private final SimpMessagingTemplate template;
+
+    @EventListener
+    public void onSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = accessor.getDestination();
+        var principal = accessor.getUser();
+        if (destination == null || principal == null) return;
+        log.info("destination : {}", destination);
+        final String prefix = "/ws/wooms/move/";
+        if (!destination.startsWith(prefix)) return;
+
+        String idStr = destination.substring(prefix.length());
+        UUID woomsId = UUID.fromString(idStr);
+        Channel channel = channelRepository.get(woomsId);
+
+        channel.getWooms().forEach(woom -> {
+            template.convertAndSendToUser(
+                    principal.getName(),
+                    "/queue/init",
+                    MoveMessage.of(woom)
+            );
+            log.info("개인 큐 발송 !");
+        });
+    }
+}

--- a/src/main/java/com/ee06/wooms/domain/chat/common/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/JwtHandshakeInterceptor.java
@@ -43,7 +43,6 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
                     if (value != null && !value.isBlank()) {
                         attrs.put(ATTR_JWT_TOKEN, value);
-                        log.info("[HS] Found JWT cookie: {} (len={})", COOKIE_NAME, value.length());
                     } else {
                         log.info("[HS] {} cookie present but empty", COOKIE_NAME);
                     }

--- a/src/main/java/com/ee06/wooms/domain/chat/common/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/JwtHandshakeInterceptor.java
@@ -1,0 +1,65 @@
+package com.ee06.wooms.domain.chat.common;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import jakarta.servlet.http.Cookie;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    // 🔧 실제 쿠키 이름으로 바꿔줘 (예: "ACCESS_TOKEN" 또는 "WOOMS_AT")
+    private static final String COOKIE_NAME = "Authorization";
+    public static final String ATTR_JWT_TOKEN = "JWT_TOKEN";
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest req, ServerHttpResponse res,
+                                   WebSocketHandler wsHandler, Map<String, Object> attrs) {
+        if (req instanceof ServletServerHttpRequest sreq) {
+            var http = sreq.getServletRequest();
+
+            Cookie[] cookies = http.getCookies();
+            if (cookies != null) {
+                for (Cookie c : cookies) {
+                    if (!COOKIE_NAME.equals(c.getName())) continue;
+
+                    String raw = c.getValue();
+                    String value = raw != null ? URLDecoder.decode(raw, StandardCharsets.UTF_8) : null;
+
+                    if (value != null && value.startsWith("Bearer ")) {
+                        value = value.substring(7);
+                    }
+
+                    if (value != null && !value.isBlank()) {
+                        attrs.put(ATTR_JWT_TOKEN, value);
+                        log.info("[HS] Found JWT cookie: {} (len={})", COOKIE_NAME, value.length());
+                    } else {
+                        log.info("[HS] {} cookie present but empty", COOKIE_NAME);
+                    }
+                    break;
+                }
+            } else {
+                log.info("[HS] No cookies on handshake");
+            }
+
+        }
+        return true; // 쿠키 없어도 연결 자체는 열어둔다(권한은 이후 단계에서 제한)
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        // no-op
+    }
+}

--- a/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
@@ -13,6 +13,7 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -34,6 +35,13 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             String sessionId = accessor.getSessionId();
 
             log.info("STOMP Connection - Session ID: {}", sessionId);
+            Object nativeHeadersObj = accessor.getMessageHeaders().get(NativeMessageHeaderAccessor.NATIVE_HEADERS);
+            if (nativeHeadersObj instanceof java.util.Map<?, ?> map) {
+                log.info("일단 들어옴");
+                @SuppressWarnings("unchecked")
+                var nativeHeaders = (java.util.Map<String, java.util.List<String>>) map;
+                nativeHeaders.forEach((k, v) -> log.info("STOMP native header [{}] = {}", k, v));
+            }
 
             // Principal.getName() == sessionId 로 사용
             accessor.setUser(new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(sessionId, null));

--- a/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
@@ -32,20 +32,26 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
             // STOMP 연결 시점
             String sessionId = accessor.getSessionId();
+
             log.info("STOMP Connection - Session ID: {}", sessionId);
 
-            // 토큰 처리
+            // Principal.getName() == sessionId 로 사용
+            accessor.setUser(new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(sessionId, null));
+
             String token = accessor.getFirstNativeHeader("Authorization");
+            if (token == null) token = accessor.getFirstNativeHeader("authorization");
+
             if (token != null && jwtUtil.validateToken(token)) {
                 try {
                     String nickname = jwtUtil.getNickname(token);
                     Integer costume = Integer.valueOf(jwtUtil.getCostume(token));
                     String channelUuidStr = jwtUtil.getChannelUuid(token);
-
+                    log.info("channelUUidStr: {}", channelUuidStr);
                     // Woom 객체 생성 및 저장
                     Woom woom = new Woom(nickname, costume, null);
                     if (channelUuidStr != null && !channelUuidStr.isEmpty()) {
                         UUID channelUuid = UUID.fromString(channelUuidStr);
+                        log.info("channelUUid: {}", channelUuid);
                         woom.setWoomsId(channelUuid);
 
                         Channel channels = channelRepository.get(channelUuid);

--- a/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
@@ -1,8 +1,6 @@
 package com.ee06.wooms.domain.chat.common;
 
-import com.ee06.wooms.domain.chat.ChannelRepository;
 import com.ee06.wooms.domain.chat.SessionRepository;
-import com.ee06.wooms.domain.chat.entity.Channel;
 import com.ee06.wooms.domain.chat.entity.Woom;
 import com.ee06.wooms.global.jwt.JWTUtil;
 import lombok.RequiredArgsConstructor;
@@ -13,66 +11,50 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
-import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
-
-import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class StompChannelInterceptor implements ChannelInterceptor {
     private final JWTUtil jwtUtil;
-    private final ChannelRepository channelRepository;
     private final SessionRepository sessionRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        StompHeaderAccessor acc = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (acc == null) return message;
 
-        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-            // STOMP 연결 시점
-            String sessionId = accessor.getSessionId();
+        if (StompCommand.CONNECT.equals(acc.getCommand())) {
+            String sessionId = acc.getSessionId();
 
-            log.info("STOMP Connection - Session ID: {}", sessionId);
-            Object nativeHeadersObj = accessor.getMessageHeaders().get(NativeMessageHeaderAccessor.NATIVE_HEADERS);
-            if (nativeHeadersObj instanceof java.util.Map<?, ?> map) {
-                log.info("일단 들어옴");
-                @SuppressWarnings("unchecked")
-                var nativeHeaders = (java.util.Map<String, java.util.List<String>>) map;
-                nativeHeaders.forEach((k, v) -> log.info("STOMP native header [{}] = {}", k, v));
+            // 개인 큐용 Principal (세션ID 기반)
+            acc.setUser(new UsernamePasswordAuthenticationToken(sessionId, null));
+
+
+            String token = (String) acc.getSessionAttributes().get(JwtHandshakeInterceptor.ATTR_JWT_TOKEN);
+
+            boolean valid = false;
+            if (token != null && !token.isBlank()) {
+                try { valid = jwtUtil.validateToken(token); }
+                catch (Exception e) { log.warn("JWT validate failed: {}", e.getMessage()); }
             }
+            log.info("[CONNECT] tokenPresent={}, valid={}", token != null, valid);
 
-            // Principal.getName() == sessionId 로 사용
-            accessor.setUser(new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(sessionId, null));
-
-            String token = accessor.getFirstNativeHeader("Authorization");
-            if (token == null) token = accessor.getFirstNativeHeader("authorization");
-
-            if (token != null && jwtUtil.validateToken(token)) {
+            if (valid) {
                 try {
                     String nickname = jwtUtil.getNickname(token);
                     Integer costume = Integer.valueOf(jwtUtil.getCostume(token));
-                    String channelUuidStr = jwtUtil.getChannelUuid(token);
-                    log.info("channelUUidStr: {}", channelUuidStr);
-                    // Woom 객체 생성 및 저장
-                    Woom woom = new Woom(nickname, costume, null);
-                    if (channelUuidStr != null && !channelUuidStr.isEmpty()) {
-                        UUID channelUuid = UUID.fromString(channelUuidStr);
-                        log.info("channelUUid: {}", channelUuid);
-                        woom.setWoomsId(channelUuid);
-
-                        Channel channels = channelRepository.get(channelUuid);
-                        channels.addWoom(woom);
-                        channelRepository.put(channelUuid, channels);
-                    }
-
-                    // STOMP 세션 ID로 저장
-                    sessionRepository.put(sessionId, woom);
-                    log.info("Stored user {} with STOMP session: {}", nickname, sessionId);
+                    // woomsId는 SUBSCRIBE 경로에서 확정
+                    sessionRepository.put(sessionId, new Woom(nickname, costume, null));
+                    log.info("Session bound: {} -> {}", sessionId, nickname);
                 } catch (Exception e) {
-                    log.error("Error processing STOMP connection: ", e);
+                    log.error("JWT parse error", e);
                 }
+            } else {
+                // 자동 재연결 루프 방지
+                // 필요 시 익명 사용자로 진행
             }
         }
         return message;

--- a/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
@@ -42,7 +42,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                 try { valid = jwtUtil.validateToken(token); }
                 catch (Exception e) { log.warn("JWT validate failed: {}", e.getMessage()); }
             }
-            log.info("[CONNECT] tokenPresent={}, valid={}", token != null, valid);
 
             if (valid) {
                 try {

--- a/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/StompChannelInterceptor.java
@@ -14,6 +14,8 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -47,8 +49,9 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     String nickname = jwtUtil.getNickname(token);
                     Integer costume = Integer.valueOf(jwtUtil.getCostume(token));
                     // woomsId는 SUBSCRIBE 경로에서 확정
-                    sessionRepository.put(sessionId, new Woom(nickname, costume, null));
-                    log.info("Session bound: {} -> {}", sessionId, nickname);
+                    String channelUuid = jwtUtil.getChannelUuid(token);
+                    sessionRepository.put(sessionId, new Woom(nickname, costume, UUID.fromString(channelUuid)));
+                    log.info("Session bound: {} -> {}, {}", sessionId, nickname, channelUuid);
                 } catch (Exception e) {
                     log.error("JWT parse error", e);
                 }

--- a/src/main/java/com/ee06/wooms/domain/chat/common/WebSocketConfig.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/WebSocketConfig.java
@@ -19,6 +19,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompChannelInterceptor stompChannelInterceptor;
     private final StompErrorHandler errorHandler;
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
 
     @Bean
     public ThreadPoolTaskScheduler wsTaskScheduler() {
@@ -33,6 +34,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.setErrorHandler(errorHandler)
                 .addEndpoint("/ws")
+                .addInterceptors(jwtHandshakeInterceptor)
             .setAllowedOrigins("http://localhost:5173","http://localhost:3000","https://wooms.duckdns.org");
     }
 

--- a/src/main/java/com/ee06/wooms/domain/chat/common/WebSocketConfig.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/common/WebSocketConfig.java
@@ -2,9 +2,11 @@ package com.ee06.wooms.domain.chat.common;
 
 import com.ee06.wooms.domain.chat.exception.StompErrorHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -17,6 +19,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompChannelInterceptor stompChannelInterceptor;
     private final StompErrorHandler errorHandler;
+
+    @Bean
+    public ThreadPoolTaskScheduler wsTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("wss-heartbeat-");
+        scheduler.initialize();
+        return scheduler;
+    }
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.setErrorHandler(errorHandler)
@@ -26,8 +38,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setApplicationDestinationPrefixes("/ws/send");
-        registry.enableSimpleBroker("/ws/wooms", "/ws/wooms/disconnect");
+        registry.setApplicationDestinationPrefixes("/ws/send")
+                .enableSimpleBroker("/ws/wooms", "/ws/wooms/disconnect", "/queue")
+                .setTaskScheduler(wsTaskScheduler())
+                .setHeartbeatValue(new long[]{10_000, 10_000});
+
+        registry.setUserDestinationPrefix("/user");
     }
 
     @Override

--- a/src/main/java/com/ee06/wooms/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/controller/ChatController.java
@@ -29,21 +29,21 @@ public class ChatController {
     private final SimpMessagingTemplate template;
     private final ChannelRepository channelRepository;
 
-    @PostMapping("/api/join/{woomsId}")
-    public CommonResponse join(@PathVariable("woomsId") UUID woomsId) {
-        Channel channel = channelRepository.get(woomsId);
-        channel.getWooms().forEach(woom1 ->
-                {
-                    try {
-                        log.info("woom : {} ", MoveMessage.of(woom1));
-                        template.convertAndSend("/ws/wooms/move/" + woomsId, objectMapper.writeValueAsString(MoveMessage.of(woom1)));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-        );
-        return new CommonResponse("ok");
-    }
+//    @PostMapping("/api/join/{woomsId}")
+//    public CommonResponse join(@PathVariable("woomsId") UUID woomsId) {
+//        Channel channel = channelRepository.get(woomsId);
+//        channel.getWooms().forEach(woom1 ->
+//                {
+//                    try {
+//                        log.info("woom : {} ", MoveMessage.of(woom1));
+//                        template.convertAndSend("/ws/wooms/move/" + woomsId, objectMapper.writeValueAsString(MoveMessage.of(woom1)));
+//                    } catch (JsonProcessingException e) {
+//                        throw new RuntimeException(e);
+//                    }
+//                }
+//        );
+//        return new CommonResponse("ok");
+//    }
 
     @MessageMapping("/chat/{woomsId}")
     public void sendMessage(@DestinationVariable("woomsId") UUID woomsId,

--- a/src/main/java/com/ee06/wooms/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/controller/ChatController.java
@@ -59,7 +59,8 @@ public class ChatController {
                      String content) throws Exception {
         MoveMessage moveMessage = objectMapper.readValue(content, MoveMessage.class);
 
-        channelRepository.get(woomsId).moveWoom(new Woom(moveMessage.getNickname(), moveMessage.getCostume(), woomsId), moveMessage);
+        channelRepository.get(woomsId).moveWoom(woomsId, moveMessage);
+
         log.info("moveMessage: {}", moveMessage);
         template.convertAndSend("/ws/wooms/move/" + woomsId, objectMapper.writeValueAsString(moveMessage));
     }

--- a/src/main/java/com/ee06/wooms/domain/chat/entity/Channel.java
+++ b/src/main/java/com/ee06/wooms/domain/chat/entity/Channel.java
@@ -2,26 +2,44 @@ package com.ee06.wooms.domain.chat.entity;
 
 import com.ee06.wooms.domain.chat.dto.MoveMessage;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class Channel {
-    Set<Woom> wooms;
 
-    public Channel() {
-        wooms = new HashSet<>();
+    private final ConcurrentMap<String, Woom> wooms = new ConcurrentHashMap<>();
+    private static String key(String nickname, UUID woomsId) {
+        return nickname + "|" + woomsId;
     }
+
     public void addWoom(Woom woom) {
-        wooms.add(woom);
+        if (woom == null || woom.getNickname() == null || woom.getWoomsId() == null) return;
+        wooms.put(key(woom.getNickname(), woom.getWoomsId()), woom);
     }
+
     public void removeWoom(Woom woom) {
-        wooms.remove(woom);
+        if (woom == null || woom.getNickname() == null || woom.getWoomsId() == null) return;
+        wooms.remove(key(woom.getNickname(), woom.getWoomsId()));
     }
-    public void moveWoom(Woom woom, MoveMessage moveMessage){
-        woom.move(moveMessage);
-        wooms.add(woom);
+
+    public void moveWoom(UUID woomsId, MoveMessage moveMessage) {
+        if (moveMessage == null || moveMessage.getNickname() == null || woomsId == null) return;
+        String k = key(moveMessage.getNickname(), woomsId);
+        wooms.compute(k, (ignored, existing) -> {
+            if (existing == null) {
+                Woom nw = new Woom(moveMessage.getNickname(), moveMessage.getCostume(), woomsId);
+                nw.move(moveMessage);
+                return nw;
+            } else {
+                existing.move(moveMessage);
+                return existing;
+            }
+        });
     }
-    public Set<Woom> getWooms() {
-        return wooms;
+
+    public Collection<Woom> getWooms() {
+        return wooms.values();
     }
 }

--- a/src/main/java/com/ee06/wooms/global/util/CookieUtils.java
+++ b/src/main/java/com/ee06/wooms/global/util/CookieUtils.java
@@ -3,13 +3,35 @@ package com.ee06.wooms.global.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
+@Component
 public class CookieUtils {
+
+    private static boolean secure;
+
+    private static String samesite;
+
+    @Value("${cookie.secure}")
+    public void setSecure(String secure) {
+        this.secure = Boolean.valueOf(secure);
+    }
+
+    @Value("${cookie.samesite}")
+    public void setSamesite(String samesite) {
+        this.samesite = samesite;
+    }
+
     public static String getCookie(HttpServletRequest request, String name) {
         return Optional.ofNullable(request.getCookies())
                 .flatMap(cookies -> Arrays.stream(cookies)
@@ -20,14 +42,20 @@ public class CookieUtils {
     }
 
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        System.out.println(secure);
+        System.out.println(samesite);
+
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")
-                .sameSite("None")
-                .httpOnly(true)
-                .secure(true)
+                .sameSite(samesite)
+                .httpOnly(secure)
+                .secure(secure)
                 .maxAge(maxAge)
                 .build();
 
         response.addHeader("Set-Cookie", cookie.toString());
     }
 }
+
+
+

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -40,3 +40,6 @@ spring.ai.openai.audio.speech.base-url=https://api.openai.com/v1/audio/speech
 # prometheus
 management.endpoints.web.exposure.include=health,info,prometheus,metrics
 management.endpoint.prometheus.enabled=true
+
+cookie.secure=true
+cookie.samesite=None


### PR DESCRIPTION
## 🙆‍♂️ Issue

#160 

## 📝 Description

* 입장 직후 기존 인원이 바로 보이지 않던 문제를 해결했습니다. 구독 시점에 개인 큐로 스냅샷을 내려줍니다. 
* `/user/queue/...` 구독을 사용하며 이는 Spring의 User Destination메커니즘을 통해 세션별 전용 목적지로 라우팅됩니다. 

* 사용자가 이탈해도 타 화면에서 유령 캐릭터가 남던 문제를 해결했습니다. 서버는 세션 종료 시 sessionId 기반으로 채널에서 제거 후 방 브로드캐스트를 보냅니다.
* 장시간 대기 후 세션 종료가 늦게 감지되는 문제는 SimpleBroker heartbeat를 명시 설정하여 개선했습니다. 서버에 TaskScheduler를 등록하고 브로커에 heartbeat 값을 지정하면 하트비트를 지원합니다. 

## ✨ Feature

### 1) 쿠키 기반 인증 · 세션 결합

* **HandshakeInterceptor** 에서 `HttpServletRequest#getCookies()`로 **HttpOnly Secure 쿠키**의 토큰을 읽어 **세션 속성**(`attrs`)에 저장합니다. (WebSocket 핸드셰이크 단계에서만 접근 가능)
* **StompChannelInterceptor (CONNECT)**

  * 핸드셰이크에서 저장한 토큰을 검증 후, `StompHeaderAccessor#setUser(...)` 로 **Principal = STOMP sessionId**를 부여합니다. 이후 `convertAndSendToUser`에서 이 Principal을 사용해 특정 사용자(세션)에게 메시지를 보낼 수 있습니다.

### 2) 구독 시 스냅샷(개인 큐 전송)

* **SessionSubscribeEvent** 를 리스닝하여 `/ws/wooms/move/{woomsId}` 구독이 발생하면, 해당 세션의 `Woom`을 채널에 등록하고, **현재 채널 인원 스냅샷**을 `/user/queue/init`으로 전송합니다. (subscribe 이벤트는 STOMP SUBSCRIBE 수신 시 발행) 
* 개인 큐 전송은 `SimpMessagingTemplate#convertAndSendToUser(user, "/queue/init", payload)` 를 사용합니다. 
### 3) MOVE 업서트 (sessionId 키)

* `Channel` 저장구조를 `ConcurrentMap<String /*sessionId*/, Woom>` 으로 변경하고, `moveWoom(sessionId, woomsId, msg)`를 **업서트**로 구현했습니다.
* `@MessageMapping("/move/{woomsId}")` 처리 시 서버가 `Principal#getName()`에서 **sessionId를 강제 주입**하여 신뢰 가능한 식별자로 저장/브로드캐스트합니다. (클라 조작 방지) 

### 4) DISCONNECT 브로드캐스트

* **SessionDisconnectEvent**에서 `sessionId` 기준으로 채널에서 제거하고 `/ws/wooms/disconnect/{woomsId}`로 브로드캐스트합니다. 모든 클라는 `sessionId` 기준으로 즉시 제거합니다.
* 구독 이벤트·해제 이벤트의 의미와 타이밍은 Spring 이벤트 문서를 참고했습니다.

### 5) Heartbeat 설정

* `ThreadPoolTaskScheduler` 를 Bean으로 등록하고, `enableSimpleBroker(...).setTaskScheduler(...).setHeartbeatValue(new long[]{10000,10000})` 로 하트비트를 명시합니다. (서버-클라 왕복 10초 예시)

## 🔧 Code Touch (요약)

* `common/JwtHandshakeInterceptor.java` : 쿠키 → 세션 속성 저장
* `common/StompChannelInterceptor.java` : CONNECT 시 인증/`Principal=sessionId` 설정
* `common/ChannelSubscribeListener.java` : SUBSCRIBE 시 채널 등록 + **convertAndSendToUser** 로 스냅샷 전송
* `controller/ChatController.java` : `move` 처리에서 `Principal(sessionId)` 주입 후 업서트 & 브로드캐스트
* `common/ChannelDisconnectListener.java` : DISCONNECT 시 sessionId 기반 제거 & 방 브로드캐스트
* `entity/Channel.java` : `ConcurrentMap<sessionId, Woom>` 업서트/제거
* `config/WebSocketConfig.java` : `TaskScheduler` + `setHeartbeatValue(...)` 적용


## 👌 Review

This closes #160 